### PR TITLE
adding POST user to API

### DIFF
--- a/handler/user/users.go
+++ b/handler/user/users.go
@@ -29,6 +29,9 @@ func router(req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, 
 		if req.Resource == "/feedback" {
 			return submitFeedback(req)
 		}
+		if req.Resource == "/user" {
+			return submitUser(req)
+		}
 	}
 	return clientError(http.StatusMethodNotAllowed, errors.New("method must be 'GET' or 'POST'"))
 }
@@ -52,6 +55,42 @@ func getUser(accountID string) (events.APIGatewayProxyResponse, error) {
 
 	return events.APIGatewayProxyResponse{
 		StatusCode: http.StatusOK,
+		Headers:    map[string]string{"content-type": "application/json", "Access-Control-Allow-Origin": "*"},
+		Body:       string(body),
+	}, nil
+}
+
+func submitUser(req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+
+	var user repository.User
+	err := json.Unmarshal([]byte(req.Body), &user)
+	if err != nil {
+		return clientError(http.StatusUnprocessableEntity, errors.New("error unmarshalling Request JSON. Check syntax"+err.Error()))
+	}
+
+	// // TODO - verify if these should actually match
+	// userID := req.Headers["from"]
+	// if userID != user.AccountID{
+	// 	return clientError(http.StatusBadRequest, errors.New("AccountID mismatch.  Header information doesn't match body"))
+	// }
+
+	// Make sure req has minimum amount of information in order to create new User
+	// Check that user has AccountID
+	if user.AccountID == "" {
+		return clientError(http.StatusBadRequest, errors.New("no AccountID specified"))
+	}
+
+	var response repository.UserResponse
+	response, err = repository.SubmitUser(user)
+	infoLogger.Println("User added: " + response.AccountID)
+
+	body, err := json.Marshal(response)
+	if err != nil {
+		return serverError(http.StatusInternalServerError, errors.New("unable to marshal JSON for user response"))
+	}
+
+	return events.APIGatewayProxyResponse{
+		StatusCode: http.StatusCreated,
 		Headers:    map[string]string{"content-type": "application/json", "Access-Control-Allow-Origin": "*"},
 		Body:       string(body),
 	}, nil

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -394,6 +394,34 @@ func SubmitRequest(request Request, accountID string) (RequestResponse, error) {
 	return response, err
 }
 
+// SubmitUser adds a new user to the Users tables with no submitted or tracked requests.
+func SubmitUser(user User) (UserResponse, error) {
+	svc, err := createDynamoClient()
+	if err != nil {
+		return UserResponse{}, err
+	}
+
+	av, err := dynamodbattribute.MarshalMap(user)
+	if err != nil {
+		return UserResponse{}, fmt.Errorf("repository: Failed to marshal user:\n %+v. \n  %s", user, err)
+	}
+
+	input := &dynamodb.PutItemInput{
+		Item:      av,
+		TableName: aws.String(UsersTable),
+	}
+
+	_, err = svc.PutItem(input)
+	if err != nil {
+		return UserResponse{}, fmt.Errorf("repository: failed to put new user in database: \n input: %+v. \n %s", input, err)
+	}
+
+	var response UserResponse
+	response.AccountID = user.AccountID
+
+	return response, err
+}
+
 // trackUserRequest updates the Users table to append a request to the list of requsts a user has created
 func trackUserRequest(requestID string, userID string) (*dynamodb.UpdateItemOutput, error) {
 	svc, err := createDynamoClient()


### PR DESCRIPTION
Per the April 8 standup, this exposes ability to add a new user to the Users DynamoDB table during cognito registration.